### PR TITLE
fix for navigation

### DIFF
--- a/app/src/main/java/com/cs446/housematehub/account/AccountDetails.java
+++ b/app/src/main/java/com/cs446/housematehub/account/AccountDetails.java
@@ -133,7 +133,7 @@ public class AccountDetails extends Fragment {
                     public void onItemClick(View view, int position) {
                         ParseUser user = mAdapter.getData().get(position);
                         Fragment newAccountDetailsFragment = AccountDetails.newInstance(user.getUsername());
-                        ((HouseMainActivity) getActivity()).loadFragment(newAccountDetailsFragment, "account_fragment_tag_" + user.getUsername(), false);
+                        ((HouseMainActivity) getActivity()).changeFragments(HouseMainActivity.TAB_EXPENSE, newAccountDetailsFragment, true);
                     }
 
                     @Override

--- a/app/src/main/java/com/cs446/housematehub/calendar/CalendarManager.java
+++ b/app/src/main/java/com/cs446/housematehub/calendar/CalendarManager.java
@@ -61,6 +61,7 @@ public class CalendarManager extends Fragment {
         rightNow = Calendar.getInstance();
         mainActivity = ((HouseMainActivity) getActivity());
         houseName = (String) mainActivity.getCurrentHouse().get("houseName");
+        getCalendarEvents();
     }
 
     @Override
@@ -94,6 +95,7 @@ public class CalendarManager extends Fragment {
             }
         });
 
+        addEventCards(inflater);
         return view;
     }
 

--- a/app/src/main/java/com/cs446/housematehub/dashboard/DashboardManager.java
+++ b/app/src/main/java/com/cs446/housematehub/dashboard/DashboardManager.java
@@ -1,0 +1,6 @@
+package com.cs446.housematehub.dashboard;
+
+import androidx.fragment.app.Fragment;
+
+public class DashboardManager extends Fragment {
+}

--- a/app/src/main/java/com/cs446/housematehub/expenses/ExpenseLog.java
+++ b/app/src/main/java/com/cs446/housematehub/expenses/ExpenseLog.java
@@ -90,7 +90,7 @@ public class ExpenseLog extends Fragment {
         View.OnClickListener userDetailsListener = new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                ((HouseMainActivity) getActivity()).loadFragment(AccountDetails.newInstance(userOther), "accountDetails", false);
+                ((HouseMainActivity) getActivity()).changeFragments(HouseMainActivity.TAB_EXPENSE, AccountDetails.newInstance(userOther), true);
             }
         };
         userFromText.setOnClickListener(userDetailsListener);

--- a/app/src/main/java/com/cs446/housematehub/expenses/ExpenseManager.java
+++ b/app/src/main/java/com/cs446/housematehub/expenses/ExpenseManager.java
@@ -210,7 +210,7 @@ public class ExpenseManager extends Fragment {
                 @Override
                 public void onClick(View v) {
                     Fragment expenseLogFragment = new ExpenseLog(username, color, currentUserName, houseName);
-                    ((HouseMainActivity) v.getContext()).loadFragment(expenseLogFragment, "ExpenseLog", false);
+                    ((HouseMainActivity) v.getContext()).changeFragments(HouseMainActivity.TAB_EXPENSE, expenseLogFragment,true);
                 }
             });
 

--- a/app/src/main/java/com/cs446/housematehub/grouplist/GroupListAdapter.java
+++ b/app/src/main/java/com/cs446/housematehub/grouplist/GroupListAdapter.java
@@ -73,7 +73,7 @@ public class GroupListAdapter extends RecyclerView.Adapter<GroupListAdapter.Grou
         holder.listContainer.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
                 Fragment fragment = new GroupListItemManager(listData.get(position).getObjectId());
-                ((HouseMainActivity) view.getContext()).loadFragment(fragment, "groupListDetails", false);
+                ((HouseMainActivity) view.getContext()).changeFragments(HouseMainActivity.TAB_LIST, fragment,true);
             }
         });
 


### PR DESCRIPTION
- Navigating through tabs maintains the state tabs were in before switching
- Each tab has its own fragment stack
- Pressing back when on the main fragment of a tab closes the app (will change this when the dashboard is completed)

![device-2020-07-20-185414](https://user-images.githubusercontent.com/32148807/87994392-ce2ced00-caba-11ea-8ec3-935c5ca7e58d.gif)
